### PR TITLE
Add start script and setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -2,4 +2,18 @@
 
 - Overview
 
-  The intended use of the Art-Gallery-App is act as a Single-Page-Application, to post/create art/paintings, and post/create artists.  You can also view art that is associated to an artist, delete the artwork, and delete the artist, deleting an artist will subsequently delete that artists paintings as a painting belongs to an artist.  To begin you would select a title for the artwork you'd like to create, a style, and set a price.  Then through the use of a Google Custom Search Engine you would search for an image to add to the form, select an artist from the drop down menu, click create painting and that would send a post fetch request to the back-end adding that painting to the database thus creating the painting.  Like wise you can create an artist by entering the name of the artist, the age, and the gender this as well sends a post fetch request to the back-end creating the artist and adding that artist to the database.  Once an artist is created they are added to the artist selection drop down menu.  If you wanted to delete a painting or artist this would send a delete fetch request to the back-end database thus removing that painting or artist from the database.
+  The intended use of the Art-Gallery-App is act as a Single-Page-Application, to post/create art/paintings, and post/create artists. You can also view art that is associated to an artist, delete the artwork, and delete the artist, deleting an artist will subsequently delete that artists paintings as a painting belongs to an artist. To begin you would select a title for the artwork you'd like to create, a style, and set a price. Then through the use of a Google Custom Search Engine you would search for an image to add to the form, select an artist from the drop down menu, click create painting and that would send a post fetch request to the back-end adding that painting to the database thus creating the painting. Like wise you can create an artist by entering the name of the artist, the age, and the gender this as well sends a post fetch request to the back-end creating the artist and adding that artist to the database. Once an artist is created they are added to the artist selection drop down menu. If you wanted to delete a painting or artist this would send a delete fetch request to the back-end database thus removing that painting or artist from the database.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm start
+   ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "art-gallery-app-frontend",
+  "version": "1.0.0",
+  "description": "Frontend for the Art Gallery App",
+  "scripts": {
+    "start": "http-server ."
+  },
+  "dependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic Node package with http-server start command
- ignore node_modules and lock file
- document install/start commands in README

## Testing
- `npm install`
- `npm start` (manually stopped)
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b2fe696dc832397dad513bf9b349e